### PR TITLE
Remove ixLock references from door on combine lock removal.

### DIFF
--- a/entities/entities/ix_combinelock.lua
+++ b/entities/entities/ix_combinelock.lua
@@ -96,10 +96,12 @@ if (SERVER) then
 
 		if (IsValid(self.door)) then
 			self.door:Fire("unlock")
+			self.door.ixLock = nil
 		end
 
 		if (IsValid(self.doorPartner)) then
 			self.doorPartner:Fire("unlock")
+			self.doorPartner.ixLock = nil
 		end
 
 		if (!ix.shuttingDown) then


### PR DESCRIPTION
Currently, ixLock is set for a door on a combine lock's creation but is never removed, this changes that.