### PR TITLE
Fix IsCombineRank call

### DIFF
--- a/schema/classes/sh_metropolice_scanner.lua
+++ b/schema/classes/sh_metropolice_scanner.lua
@@ -12,7 +12,7 @@ function CLASS:OnSpawn(client)
 		client.ixScanner.bPendingRemove = true
 		client.ixScanner:Remove()
 	else
-		Schema:CreateScanner(client, Schema:IsCombineRank(client:Name(), "SYNTH") and "npc_clawscanner" or nil)
+		Schema:CreateScanner(client, Schema:IsCombineRank(client:Name(), "SHIELD") and "npc_clawscanner" or nil)
 	end
 end
 


### PR DESCRIPTION
The rest of the Schema uses SHIELD for the shield scanner, so why would this be SYNTH?, It makes it not work.