### PR TITLE
Fixed OnTransferred for MPF and OTA

### DIFF
--- a/schema/factions/sh_metropolice.lua
+++ b/schema/factions/sh_metropolice.lua
@@ -20,7 +20,7 @@ function FACTION:GetDefaultName(client)
 	return "MPF-RCT." .. Schema:ZeroNumber(math.random(1, 99999), 5), true
 end
 
-function FACTION:OnTransfered(client)
+function FACTION:OnTransferred(client)
 	local character = client:GetCharacter()
 
 	character:SetName(self:GetDefaultName())

--- a/schema/factions/sh_metropolice.lua
+++ b/schema/factions/sh_metropolice.lua
@@ -20,9 +20,7 @@ function FACTION:GetDefaultName(client)
 	return "MPF-RCT." .. Schema:ZeroNumber(math.random(1, 99999), 5), true
 end
 
-function FACTION:OnTransferred(client)
-	local character = client:GetCharacter()
-
+function FACTION:OnTransferred(character)
 	character:SetName(self:GetDefaultName())
 	character:SetModel(self.models[1])
 end

--- a/schema/factions/sh_ota.lua
+++ b/schema/factions/sh_ota.lua
@@ -22,9 +22,7 @@ function FACTION:GetDefaultName(client)
 	return "OTA-ECHO.OWS-" .. Schema:ZeroNumber(math.random(1, 99999), 5), true
 end
 
-function FACTION:OnTransferred(client)
-	local character = client:GetCharacter()
-
+function FACTION:OnTransferred(character)
 	character:SetName(self:GetDefaultName())
 	character:SetModel(self.models[1])
 end

--- a/schema/factions/sh_ota.lua
+++ b/schema/factions/sh_ota.lua
@@ -22,7 +22,7 @@ function FACTION:GetDefaultName(client)
 	return "OTA-ECHO.OWS-" .. Schema:ZeroNumber(math.random(1, 99999), 5), true
 end
 
-function FACTION:OnTransfered(client)
+function FACTION:OnTransferred(client)
 	local character = client:GetCharacter()
 
 	character:SetName(self:GetDefaultName())


### PR DESCRIPTION
OnTransferred, a function called upon being transferred to another faction, had a minor spelling mistake in the OTA and MPF faction file, where it previously was "OnTransfered". Additionally, the function OnTransferred has one argument is a character and not a client.