### PR TITLE
Allow door lock toggle shortcut for Admin faction

### DIFF
--- a/schema/sv_hooks.lua
+++ b/schema/sv_hooks.lua
@@ -26,7 +26,7 @@ function Schema:PlayerUse(client, entity)
 		return false
 	end
 
-	if (client:IsCombine() and entity:IsDoor() and IsValid(entity.ixLock) and client:KeyDown(IN_SPEED)) then
+	if ((client:IsCombine() or client:Team() == FACTION_ADMIN) and entity:IsDoor() and IsValid(entity.ixLock) and client:KeyDown(IN_SPEED)) then
 		entity.ixLock:Toggle(client)
 		return false
 	end


### PR DESCRIPTION
Allows the Administrator faction to use SHIFT+E to toggle door locks.